### PR TITLE
Create a first implementation of a asciidoctor block processor

### DIFF
--- a/tools/drawio-asciidoctorj-blockprocessor/README.md
+++ b/tools/drawio-asciidoctorj-blockprocessor/README.md
@@ -1,0 +1,65 @@
+An asciidoctor block macro to render mxgraph blocks
+===================================================
+
+## Purpose
+This blockprocessor converts an xml representation of an [mxGraph](https://github.com/jgraph/mxgraph) into an image that is then passed on to asciidoctorj as an image block.
+
+There are multiple ways of creating mxgraphs, one of the most prominents ones is [draw.io](https://draw.io) .
+
+## Usage
+
+### Defining Blocks in Asciidoctor
+By marking literal blocks as _drawio_ this processor gets called and renders the content of that block.
+The second block parameter is used as the file name for the generated image.
+```
+[drawio,testdrawdiag]
+....
+include::diagrams/drawiotest.xml[]
+....
+```
+
+Any extra parameters passed to the block are handed through to the asciidoctor backend that is configured to allow for further customization.
+
+```
+[drawio,testdrawdiag2,float="right",align="middle"]
+....
+<?xml version="1.0" encoding="UTF-8"?><mxGraphModel dx="2086" dy="1271" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1"
+              page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <mxCell id="L3S7H67dfCK0_i4HHWqK-3"
+            style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" edge="1" parent="1"
+            source="L3S7H67dfCK0_i4HHWqK-1" target="L3S7H67dfCK0_i4HHWqK-2">
+      <mxGeometry relative="1" as="geometry"/>
+    </mxCell>
+    <mxCell id="L3S7H67dfCK0_i4HHWqK-1" value="Hallo" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+      <mxGeometry x="120" y="260" width="120" height="60" as="geometry"/>
+    </mxCell>
+    <mxCell id="L3S7H67dfCK0_i4HHWqK-2" value="Hallo2" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+      <mxGeometry x="450" y="260" width="120" height="60" as="geometry"/>
+    </mxCell>
+  </root>
+</mxGraphModel>
+....
+```
+
+### Configuration
+The processor takes some configuration options.
+The following options can either be defined at the document level or at block level, with those defined at block level overriding the document variables.
+
+| Parameter   | Description                                                 | Scope            | Default |
+|:------------|:------------------------------------------------------------|:-----------------|:--------|
+| basedir     | Base directory, relative to which other paths are resolved. | Document / Block | ""      |
+| imagedir    | Directory that images are generated in.                     | Document / Block | images  |
+| imageformat | Format for images.                                          | Document / Block | png     |
+| alttext     | Hover text for image.                                       | Block            | ""      |
+| titletext   | Title text.                                                 | Block            | ""      |
+
+### Passing variables from Maven
+When using the Maven AsciidoctorJ module, attributes defined in the pom file can be used in the document like regular variables.
+
+
+## Next steps
+This is currently a very early version of this processor. It works and generates simple graphs well enough, but for more complex graphs there are issues with spacing and some block formating not showing up correctly.
+I will look at this in the upcoming weeks.

--- a/tools/drawio-asciidoctorj-blockprocessor/pom.xml
+++ b/tools/drawio-asciidoctorj-blockprocessor/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.training</groupId>
+  <artifactId>drawioprocessor</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Training: Tools: DrawIO Asciidoctorj Blockprocessor</name>
+  <url>https://github.com/apache/incubator-training/tree/master/tools/drawiofilter</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <asciidoctorj.version>2.0.0</asciidoctorj.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.asciidoctor</groupId>
+      <artifactId>asciidoctorj</artifactId>
+      <version>${asciidoctorj.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mxgraph</groupId>
+      <artifactId>jgraphx</artifactId>
+      <version>1.10.4.2</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+      </plugin>
+    </plugins>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioBlockProcessor.java
+++ b/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioBlockProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.training.drawioprocessor;
 
 import static org.apache.training.drawioprocessor.DrawioProcessorConfig.ALT_TEXT_CONFIG;

--- a/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioBlockProcessor.java
+++ b/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioBlockProcessor.java
@@ -1,0 +1,144 @@
+package org.apache.training.drawioprocessor;
+
+import static org.apache.training.drawioprocessor.DrawioProcessorConfig.ALT_TEXT_CONFIG;
+import static org.apache.training.drawioprocessor.DrawioProcessorConfig.BASE_PATH_CONFIG;
+import static org.apache.training.drawioprocessor.DrawioProcessorConfig.IMAGE_FORMAT_CONFIG;
+import static org.apache.training.drawioprocessor.DrawioProcessorConfig.IMAGE_PATH_CONFIG;
+import static org.apache.training.drawioprocessor.DrawioProcessorConfig.TITLE_CONFIG;
+
+import com.mxgraph.io.mxCodec;
+import com.mxgraph.util.mxCellRenderer;
+import com.mxgraph.util.mxXmlUtils;
+import com.mxgraph.view.mxGraph;
+import java.awt.*;
+import java.awt.image.RenderedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.imageio.ImageIO;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.Name;
+import org.asciidoctor.extension.Reader;
+import org.w3c.dom.Document;
+
+@Name("drawio")
+public class DrawioBlockProcessor extends BlockProcessor {
+  // These default values will be used unless specified otherwise in the block attributes
+  private static final String DEFAULT_IMAGE_PATH = "images/";
+  private static final String DEFAULT_IMAGE_FORMAT = "png";
+
+  private mxGraph graph = new mxGraph();
+  private String fileName = "";
+  private String basePath = "";
+  private String imagePath = "";
+  private String altText = "";
+  private String title = "";
+  private String imageFormat = "";
+
+  public DrawioBlockProcessor(String name, Map<String, Object> config) {
+    super(name, createConfig());
+  }
+
+  @Override
+  public Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
+    graph.setHtmlLabels(true);
+    StringBuilder blockContent = new StringBuilder();
+    List<String> lines = reader.readLines();
+    for (String line : lines) {
+      blockContent.append(line);
+    }
+
+    Document doc = mxXmlUtils.parseXml(blockContent.toString());
+    mxCodec codec = new mxCodec(doc);
+    codec.decode(doc.getDocumentElement(), graph.getModel());
+    RenderedImage image = mxCellRenderer.createBufferedImage(graph, null, 1,
+        Color.WHITE, false, null);
+
+
+    initialize(parent.getDocument().getAttributes(), attributes);
+
+    try {
+      ImageIO.write(image, imageFormat, new File(basePath + imagePath + fileName));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    final HashMap<String, Object> attrs = new HashMap<String, Object>();
+
+    attributes.put("target", fileName);
+    attributes.put("alt", altText);
+    attributes.put("title", title);
+    return createBlock(parent, "image", "", attributes, new HashMap<Object, Object>());
+  }
+
+
+  private void initialize(Map<String, Object> documentAttributes, Map<String, Object> blockAttributes) {
+    // Obtain config values, priority is as follows (lower number beats higher number):
+    // 1. attributes specified in block definition
+    // 2. attributes set at document level
+    // 3. default values
+
+    // base path, image path will be resolved relative tho this path
+    basePath = ensureTrailingSlash(getAttribute(blockAttributes, documentAttributes, BASE_PATH_CONFIG, ""));
+
+    // directory name in which images are generated (relative to basePath)
+    imagePath = ensureTrailingSlash(getAttribute(blockAttributes, documentAttributes, IMAGE_PATH_CONFIG, DEFAULT_IMAGE_PATH));
+    ensureTrailingSlash(imagePath);
+
+    // hover text for image
+    altText = getAttribute(blockAttributes, documentAttributes, ALT_TEXT_CONFIG, "");
+
+    // title to show for image on slide
+    title = getAttribute(blockAttributes, documentAttributes, TITLE_CONFIG, "");
+
+    // imageformat (png, jpg, ...)
+    imageFormat = getAttribute(blockAttributes, documentAttributes, IMAGE_FORMAT_CONFIG, DEFAULT_IMAGE_FORMAT);
+
+    // filename, cannot be retrieved from attributes of document, this has to come from
+    // the block definition and is a positional argument
+    fileName = (String)blockAttributes.get("2") + "." + imageFormat;
+  }
+
+  private String getAttribute(Map<String, Object> primaryAttributes, Map<String, Object> secondaryAttributes, String key, String defaultValue) {
+    String result = "";
+    try {
+      result = (String)primaryAttributes.getOrDefault(key, getAttribute(secondaryAttributes, key, defaultValue));
+    } catch (Exception e) {
+      System.out.println("Warning: Couldn't cast value for attribute key '" + key + "' to String, falling back to default value: '" + defaultValue + "'");
+    }
+    return result;
+  }
+
+
+    private String getAttribute(Map<String, Object> attributes, String key, String defaultValue) {
+    String result = defaultValue;
+    try {
+      result = (String) attributes.getOrDefault(key, defaultValue);
+    } catch (Exception e) {
+      System.out.println("Warning: Couldn't cast value for attribute key '" + key + "' to String, falling back to default value: '" + defaultValue + "'");
+    }
+    return result;
+
+
+  }
+
+  private String ensureTrailingSlash(String path) {
+     return path.endsWith("/") ? path : path + "/";
+  }
+
+  private static Map<String, Object> createConfig() {
+    Map<String, Object> result = new HashMap<>();
+    result.put("contexts", createContextsConfig());
+    return result;
+  }
+
+  private static List<String> createContextsConfig() {
+    List<String> contexts = new ArrayList<>();
+    contexts.add(":literal");
+    return contexts;
+  }
+}

--- a/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioExtension.java
+++ b/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioExtension.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.training.drawioprocessor;
 
 import org.asciidoctor.Asciidoctor;

--- a/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioExtension.java
+++ b/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioExtension.java
@@ -1,0 +1,15 @@
+package org.apache.training.drawioprocessor;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.extension.JavaExtensionRegistry;
+import org.asciidoctor.jruby.extension.spi.ExtensionRegistry;
+
+public class DrawioExtension implements ExtensionRegistry {
+
+  @Override
+  public void register(Asciidoctor asciidoctor) {
+    final JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
+    javaExtensionRegistry.block("drawio", new DrawioBlockProcessor("drawio", null) );
+
+  }
+}

--- a/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioProcessorConfig.java
+++ b/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioProcessorConfig.java
@@ -1,0 +1,9 @@
+package org.apache.training.drawioprocessor;
+
+public class DrawioProcessorConfig {
+  public static final String BASE_PATH_CONFIG = "basedir";
+  public static final String IMAGE_PATH_CONFIG = "imagedir";
+  public static final String IMAGE_FORMAT_CONFIG = "imageformat";
+  public static final String ALT_TEXT_CONFIG = "alttext";
+  public static final String TITLE_CONFIG = "titletext";
+}

--- a/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioProcessorConfig.java
+++ b/tools/drawio-asciidoctorj-blockprocessor/src/main/java/org/apache/training/drawioprocessor/DrawioProcessorConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.training.drawioprocessor;
 
 public class DrawioProcessorConfig {

--- a/tools/drawio-asciidoctorj-blockprocessor/src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
+++ b/tools/drawio-asciidoctorj-blockprocessor/src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
@@ -1,0 +1,1 @@
+org.apache.training.drawioprocessor.DrawioExtension

--- a/tools/drawio-asciidoctorj-blockprocessor/src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
+++ b/tools/drawio-asciidoctorj-blockprocessor/src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
@@ -1,1 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 org.apache.training.drawioprocessor.DrawioExtension


### PR DESCRIPTION
This asciidoctor blockprocessor processes xml mxgraph blocks (draw.io) and creates imageblocks from these for asciidoctor.

This is an early version with a lot of room for improvement, but for now it does the job and I wanted to get it out for feedback early on.