### PR TITLE
TRAINING-20: Broken links on Mailing Lists page

### DIFF
--- a/mailing-lists.html
+++ b/mailing-lists.html
@@ -145,16 +145,16 @@
   <tbody> 
    <tr class="b"> 
     <td>Apache Training Developer List</td> 
-    <td><a href="dev-subscribe@training.apache.org">Subscribe</a></td> 
-    <td><a href="dev-unsubscribe@training.apache.org">Unsubscribe</a></td> 
-    <td><a href="dev@training.apache.org">Post</a></td> 
+    <td><a href="mailto:dev-subscribe@training.apache.org">Subscribe</a></td> 
+    <td><a href="mailto:dev-unsubscribe@training.apache.org">Unsubscribe</a></td> 
+    <td><a href="mailto:dev@training.apache.org">Post</a></td> 
     <td><a class="externalLink" href="http://mail-archives.apache.org/mod_mbox/training-dev/">mail-archives.apache.org</a></td> 
    </tr> 
    <tr class="a"> 
     <td>Apache Training Commits List</td> 
-    <td><a href="commit-subscribe@training.apache.org">Subscribe</a></td> 
-    <td><a href="commits-unsubscribe@training.apache.org">Unsubscribe</a></td> 
-    <td><a href="commits@training.apache.org">Post</a></td> 
+    <td><a href="mailto:commit-subscribe@training.apache.org">Subscribe</a></td> 
+    <td><a href="mailto:commits-unsubscribe@training.apache.org">Unsubscribe</a></td> 
+    <td><a href="mailto:commits@training.apache.org">Post</a></td> 
     <td><a class="externalLink" href="http://mail-archives.apache.org/mod_mbox/training-commits/">mail-archives.apache.org</a></td> 
    </tr> 
   </tbody> 


### PR DESCRIPTION
The links were broken as `mailto:` was missing in the anchor tag.