### PR TITLE
TRAINING-20: Broken links on Mailing Lists page

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -65,16 +65,16 @@
   <mailingLists>
     <mailingList>
       <name>Apache Training Developer List</name>
-      <subscribe>dev-subscribe@training.apache.org</subscribe>
-      <unsubscribe>dev-unsubscribe@training.apache.org</unsubscribe>
-      <post>dev@training.apache.org</post>
+      <subscribe>mailto:dev-subscribe@training.apache.org</subscribe>
+      <unsubscribe>mailto:dev-unsubscribe@training.apache.org</unsubscribe>
+      <post>mailto:dev@training.apache.org</post>
       <archive>http://mail-archives.apache.org/mod_mbox/training-dev/</archive>
     </mailingList>
     <mailingList>
       <name>Apache Training Commits List</name>
-      <subscribe>commit-subscribe@training.apache.org</subscribe>
-      <unsubscribe>commits-unsubscribe@training.apache.org</unsubscribe>
-      <post>commits@training.apache.org</post>
+      <subscribe>mailto:commit-subscribe@training.apache.org</subscribe>
+      <unsubscribe>mailto:commits-unsubscribe@training.apache.org</unsubscribe>
+      <post>mailto:commits@training.apache.org</post>
       <archive>http://mail-archives.apache.org/mod_mbox/training-commits/</archive>
     </mailingList>
   </mailingLists>


### PR DESCRIPTION
Permanent fix for TRAINING-20 because the fix in #38 would probably be undone when we publish maven site from master.

This is to fix http://training.apache.org/mailing-lists.html to have the correct a href.