### PR TITLE
[TRAINING-21] Fixes various broken or incorrect hyperlinks

### DIFF
--- a/site/src/site/asciidoc/developers/ci.adoc
+++ b/site/src/site/asciidoc/developers/ci.adoc
@@ -20,7 +20,7 @@
 
 We are currently using only Apache Jenkins for building.
 
-- Apache's Jenkins at https://builds.apache.org/view/S-Z/job/Training/
+- Apache's Jenkins at https://builds.apache.org/view/S-Z/view/Training%20(incubating)/
 
 Only build jobs on Apache's Jenkins are allowed to publish SNAPSHOT versions of the Maven artifacts to Apaches Nexus as well as auto publish generated websites to production.
 

--- a/site/src/site/asciidoc/developers/contributing.adoc
+++ b/site/src/site/asciidoc/developers/contributing.adoc
@@ -33,7 +33,7 @@ This list is by no means finite. There are without doubt dozens of other useful 
 - Writing documentation
 
 === Finding a Project
-If you want to get involved, but do not have a specific project in mind please feel free to check our issue tracker for https://issues.apache.org/Jira/issues/?jql=project%20%3D%20TRAINING%20AND%20labels%20%3D%20beginner%20AND%20assignee%20in%20(EMPTY)[unassigned issues with the _beginner_ label]. These should be good candidates to get your feet wet and gather some experience before tackling larger issues.
+If you want to get involved, but do not have a specific project in mind please feel free to check our issue tracker for https://issues.apache.org/jira/issues/?jql=project%20%3D%20TRAINING%20AND%20labels%20%3D%20beginner%20AND%20assignee%20in%20(EMPTY)[unassigned issues with the _beginner_ label]. These should be good candidates to get your feet wet and gather some experience before tackling larger issues.
 
 If nothing catches your eye and you come up with something that you want to work on by yourself, please do share your intent by either posting on the mailing list or creating an issue, as this allows us to limit duplication of effort as much as possible.
 

--- a/site/src/site/asciidoc/developers/decisions.adoc
+++ b/site/src/site/asciidoc/developers/decisions.adoc
@@ -22,7 +22,7 @@
 
 This document describes the roles and responsibilities of the project, who may vote, how voting works, how conflicts are resolved, etc.
 
-The https://www.apache.org/foundation/faq[Apache Foundation FAQ] and http://www.apache.org/foundation/faq.html[How-It-Works] explain the operation and background of the foundation. Terms used are defined in the https://www.apache.org/foundation/glossary[ASF glossary].
+The https://www.apache.org/foundation/faq[Apache Foundation FAQ] and https://apache.org/foundation/how-it-works.html[How-It-Works] explain the operation and background of the foundation. Terms used are defined in the https://www.apache.org/foundation/glossary[ASF glossary].
 
 Apache has a http://www.apache.org/foundation/policies/conduct.html[code of conduct] that it expects its members to follow.
 

--- a/site/src/site/asciidoc/developers/website.adoc
+++ b/site/src/site/asciidoc/developers/website.adoc
@@ -34,7 +34,7 @@ The site content itself is generated from `asciidoc` files (ending `.adoc`) whic
 
 Beyond the basic goodies, the build is also configured to generate images from ASCII data using the `asciidoctor-diagram` plugin.
 
-This allows us to generate images like the ones on the hhttp://plc4x.apache.org/plc4j/plc4j-protocols/plc4j-protocol-s7/index.html[S7 Protocol Description page]
+This allows us to generate images like the ones on the http://plc4x.apache.org/plc4j/plc4j-protocols/plc4j-protocol-s7/index.html[S7 Protocol Description page]
 
 === Providing new content
 

--- a/site/src/site/asciidoc/developers/website.adoc
+++ b/site/src/site/asciidoc/developers/website.adoc
@@ -34,7 +34,7 @@ The site content itself is generated from `asciidoc` files (ending `.adoc`) whic
 
 Beyond the basic goodies, the build is also configured to generate images from ASCII data using the `asciidoctor-diagram` plugin.
 
-This allows us to generate images like the ones on the http://4x.apache.org/protocols/s7/index.html[S7 Protocol Description page]
+This allows us to generate images like the ones on the hhttp://plc4x.apache.org/plc4j/plc4j-protocols/plc4j-protocol-s7/index.html[S7 Protocol Description page]
 
 === Providing new content
 


### PR DESCRIPTION
As addressed on [TRAINING-21](https://issues.apache.org/jira/projects/TRAINING/issues/TRAINING-21), this PR fixes the broken/404 hyperlinks that I found on training.a.o.