### PR TITLE
TRAINING-26: Select english language for jetty run.

### DIFF
--- a/content/ZooKeeper/README.md
+++ b/content/ZooKeeper/README.md
@@ -30,9 +30,11 @@ By running the following command, you can generate the presentation:
    
 ## Running the presentation
 
-In order to start a local web server serving the presentation, execute the following command:
+In order to start a local web server serving the presentation (English translation), execute the following command:
 
     mvn jetty:run-exploded
+
+(The selected language is configurable in the `<configuration><war>` element of the `jetty` plugin in `pom.xml`.)
     
 As soon as that's done, just point your browser to:
 

--- a/content/ZooKeeper/pom.xml
+++ b/content/ZooKeeper/pom.xml
@@ -331,6 +331,9 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty-maven-plugin.version}</version>
+                <configuration>
+                    <war>${project.build.directory}/${project.artifactId}-${project.version}-en.war</war>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Zookeeper is an example creating two artifacts for English and German language, and `jetty:run-exploded` refers to neither of them causing an error when following the README.

This PR serves the English language by default, but describes how to reconfigure jetty to run the German version in the README.