### PR TITLE
TRAINING-25: Fix typos in Ignite build.

### DIFF
--- a/content/Ignite/pom.xml
+++ b/content/Ignite/pom.xml
@@ -214,7 +214,7 @@
                 <version>3.2.2</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
-                    <warSourceDirectory>src/target/generated-slides</warSourceDirectory>
+                    <warSourceDirectory>${project.slides.directory}</warSourceDirectory>
                 </configuration>
             </plugin>
             <plugin>

--- a/content/Ignite/src/main/asciidoc/index.adoc
+++ b/content/Ignite/src/main/asciidoc/index.adoc
@@ -19,7 +19,7 @@
 :revealjs_progress: true
 :revealjs_slidenumber: true
 :sourcedir: ../java
-:imagesdir: ../resources/images
+:imagesdir: images
 
 == What is Apache Ignite?
 Apache Ignite™ is a memory-centric distributed database, caching, and processing platform.


### PR DESCRIPTION
Some minor typographical errors in the Ignite build, causing missing resources when running `mvn jetty:run-exploded`