### PR TITLE
TRAINING-24: Add documentation on building with docker.

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -17,40 +17,10 @@
 #############################################################################
 # Dockerfile with many of the tools necessary for diagram generation
 #
-# A comprehensive list of asciidoctor diagramming tools and their
-# requirements can be found at:
-# - https://github.com/asciidoctor/asciidoctor-diagram
-#
-# You can find examples in the tools/maven-revealjs-asciidocter-template/
-# presentation. A typical presentation will not use ALL of these tools.
-#
-# To build this image:
-#
-# docker image build --build-arg USER_ID=$(id -u ${USER}) --build-arg GROUP_ID=$(id -g ${USER}) -t training-build .
-#
-# (Passing the `USER_ID` and `GROUP_ID` is useful to build presentations with
-# the same user and permissions inside the docker container.)
-#
-# To build a presentation using this image:
-#
-# cd incubator-training/tools/maven-revealjs-asciidoctor-template/
-# docker run -it --rm --volume $PWD:/opt/workdir training-build:latest -c "mvn clean package"
-#
-# Alternatively, you can include a reference to your local .m2 to speed up the build:
-#
-# docker run -it --rm --volume $HOME/.m2:/home/docker-user/.m2 --volume $PWD:/opt/workdir training-build:latest
-#
-# To run the presentation using jetty:
-#
-# docker run -it --rm --publish 58080:8080/tcp --volume $HOME/.m2:/home/docker-user/.m2 --volume $PWD:/opt/workdir training-build:latest -c "mvn jetty:run-exploded"
-#
-# Alternatively, you can serve the pages in the target/generated-slides/
-# directory using any web server:
-#
-# docker run -d --name my-tmp-httpd -p 58080:80 -v $PWD/target/generated-slides/:/usr/local/apache2/htdocs/:ro httpd:2.4
+# See tools/maven-revealjs-asciidoctor-template/README.md for usage.
 #
 
-# Start bt building some tools using a multistage docker.
+# Start by building some tools using a multistage docker
 # ===========================================================================
 
 FROM haskell:8 as tool-haskell-builder
@@ -89,7 +59,7 @@ RUN python3 -m pip install --upgrade pip setuptools seqdiag blockdiag \
     actdiag nwdiag
 
 # Meme generator ------------------------------------------------------------
-# Requires: ImageMagick (for convert and
+# Requires: ImageMagick (for convert and identify)
 RUN dnf install -y epel-release
 RUN dnf install -y ImageMagick
 

--- a/tools/maven-revealjs-asciidoctor-template/README.md
+++ b/tools/maven-revealjs-asciidoctor-template/README.md
@@ -17,31 +17,78 @@
 
 -->
 
-# Presentation with Reveal.JS and AsciiDoctor
+# Example presentation with Reveal.JS and Asciidoctor
 
-Remarks:
-- Currently it seems as if the system can't detect the 'docinfo' files, so we have to replace the `document.html.slim` file from `asciidoctor-reveal.js` with an updated one, that adds some additional js and css references. This template is located in `libs/docinfo-hack`.
-- In order to use the preview of the IntelliJ asciidoctor plugin, you need to set an attribute in the plugin settings: `imagesdir` = `../resources/images`
-- Even if it is possible to run the presentation directly from the `generated-slides` directory, some JavaScript extensions don't work in this case. Therefore it is required to run the presentation from a local webserver. 
-- In order to generate the diagrams, GraphVIS needs to be installed locally. Get it from: http://www.graphviz.org/
-- The template is adjusted to use the codecentric font `Panton`, so be sure to have that installed on your presentation machine.
-- Any css adjustments can go to `src/main/theme/cc.css` as this is automatically embedded into the themes directory.
+This directory contains a template project demonstrating:
+
+* creating slides from human-readable markup using [Asciidoctor](https://asciidoctor.org/),
+* presented in a web browser using [Reveal.JS](https://revealjs.com) instead of proprietary presentation software, and 
+* built and optionally served using [maven](https://maven.apache.org/). 
+
+Notably, this template shows off many of the diagramming tools that can be used with
+asciidoctor, including:  
+
+* [PlantUML](http://plantuml.com/) <!-- and [Mermaid](https://mermaidjs.github.io/) --> for generating UML diagrams, 
+* [Svgbob](https://github.com/ivanceras/svgbob) and [ditaa](http://ditaa.sourceforge.net/) for generating diagrams from ASCII art,
+* [Graphviz](http://www.graphviz.org/) for general graph visualization diagrams,
+* [erd](https://github.com/BurntSushi/erd) for entity-relational diagrams,
+* [blockdiag](http://blockdiag.com/en/) and its family of tools for network, sequence, rack diagrams, etc., 
+* [Syntrax](https://kevinpt.github.io/syntrax/) for railroad diagrams, and  
+* [Vega](https://vega.github.io/vega/) for interactive data visualizations.
 
 ## Building the presentation
 
-By running the following command, you can generate the presentation:
+Images are generated using the asciidoctor-diagram project, which integrates [many external tools](https://github.com/asciidoctor/asciidoctor-diagram#specifying-diagram-generator-paths).  Not all presentations will use every tool, but you may need to install some additional software.  
+
+### Installing the diagramming tools 
+
+There are example installation scripts for [Mac](./install-deps-mac.sh) and [linux](./install-deps-centos.sh).
+  
+With the external tools installed (or if your presentation doesn't use images that require external tools), building is as simple as:
 
     mvn clean package
-   
+
+### Using the diagramming tools inside docker 
+
+Alternatively, you can use a docker image containing all of the necessary tools:
+
+    # Build the docker image (once).  Takes about 20 minutes.
+    cd incubator-training/tools
+    docker image build --build-arg USER_ID=$(id -u ${USER}) \
+      --build-arg GROUP_ID=$(id -g ${USER}) -t training-build .
+    
+    # Build the presentation inside the docker image.
+    cd incubator-training/tools/maven-revealjs-asciidoctor-template
+    docker run -it --rm --volume $HOME/.m2:/home/docker-user/.m2 \
+      --volume $PWD:/opt/workdir training-build:latest
+
+* Passing the `USER_ID` and `GROUP_ID` is useful to build presentations with the same user and permissions inside the docker container.
+* The `--volume $HOME/.m2:/home/docker-user/.m2` is optional.  Using your local maven `.m2` can significantly speed up the build.
+
 ## Running the presentation
+
+The presentation is generated in `target/generated-slides`.  Even if it is possible to run the presentation directly from this directory, some JavaScript extensions don't work in this case. It is highly recommended to run the presentation from a webserver. 
 
 In order to start a local web server serving the presentation, execute the following command:
 
     mvn jetty:run-exploded
     
-As soon as that's done, just point your browser to:
+As soon as that's done, just point your browser to **[http://localhost:8080/](http://localhost:8080/)**.
 
-    http://localhost:8080/
+You can run the same jetty webserver in a docker container.  This can be useful if you want to run multiple presentations using dfferent ports. 
+
+    docker run -it --rm --publish 58080:8080/tcp \
+        --volume $HOME/.m2:/home/docker-user/.m2 \
+        --volume $PWD:/opt/workdir training-build:latest \
+        -c "mvn jetty:run-exploded"
+
+
+Alternatively, you can upload or serve the pages using any web server:
+
+    # Demonstrates serving a directory with the Apache HTTP Server
+    docker run -d --publish 58080:80 \
+         --volume $PWD/target/generated-slides/:/usr/local/apache2/htdocs/:ro \
+         httpd:2.4
 
 ## Generating PDF versions
 
@@ -52,6 +99,15 @@ The following link should do the trick:
     http://localhost:8080/?print-pdf
     
 As soon as that's loaded, just use the normal `print` functionality of the browser and `print as PDF`.
+
+# Implementation details
+- Currently it seems as if the system can't detect the 'docinfo' files, so we have to replace the `document.html.slim` file from `asciidoctor-reveal.js` with an updated one, that adds some additional js and css references. This template is located in `libs/docinfo-hack`.
+- In order to use the preview of the IntelliJ asciidoctor plugin, you need to set an attribute in the plugin settings: `imagesdir` = `../resources/images`
+- The template is adjusted to use the fontfabric [**Panton** font](https://www.fontfabric.com/fonts/panton/), so be sure to have that installed on your presentation machine.
+- Any css adjustments can go to `src/main/theme/cc.css` as this is automatically embedded into the themes directory.
+
+
+<!-- These need to be re-integrated into the presentation and installation scripts.
 
 ## Installing third party software:
 
@@ -64,3 +120,4 @@ This will install mermaid under `node_modules/.bin/mmdc`.
 ### PhantomJS
 
 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip
+-->

--- a/tools/maven-revealjs-asciidoctor-template/src/main/asciidoc/index.adoc
+++ b/tools/maven-revealjs-asciidoctor-template/src/main/asciidoc/index.adoc
@@ -21,7 +21,7 @@ include::_settings.adoc[]
 :presenter_name: Some Cool Person
 :presenter_company: Apache Software Foundation
 
-== Example Presentation
+== Example presentation with Reveal.JS and Asciidoctor
 Doc Writer <cool.person@apache.org>
 {docdate}
 :revnumber: {project-version}


### PR DESCRIPTION
The current doc for using Docker to build presentations was hidden in the Dockerfile.  I propose moving them to the revealjs template presentation page.

At the same time, I did some reorganisation (on the same README.md) for the things I stumbled on while starting with the training presentations.  Hopefully, this would be a useful resource for others starting out!

* Integrated comments from #57.
