### PR TITLE
Enable syntax hightlighter.

### DIFF
--- a/content/Apache/Training/Presentations/src/main/asciidoc/index_en.adoc
+++ b/content/Apache/Training/Presentations/src/main/asciidoc/index_en.adoc
@@ -20,6 +20,9 @@
 // 45 minutes = 2700 seconds
 :revealjs_totalTime: 2700
 
+// Highlight code samples
+:source-highlighter: highlight.js
+
 == !
 :description: 45 minute talk on Apache Training
 :keywords: Apache Training
@@ -266,7 +269,7 @@ endif::[]
 ----
 
 == Generating content
-[code, python]
+[source, python]
 ----
 with urllib.request.urlopen("https://whimsy.apache.org/public/public_ldap_people.json") as url:
     data = json.loads(url.read().decode())


### PR DESCRIPTION
As per https://issues.apache.org/jira/browse/TRAINING-43 to enable python syntax hightlighting we need 

1) In the preamble to the slides we need: 

:source-highlighter: highlight.js

2) in the code block itself, we need to use 'source' rather than 'code'.