### PR TITLE
Fix broken image reference in new-presentation guide

### DIFF
--- a/site/src/site/asciidoc/users/new-presentation.adoc
+++ b/site/src/site/asciidoc/users/new-presentation.adoc
@@ -47,7 +47,7 @@ pressing `Enter` at each prompt.
 
 You'll then be asked to confirm your information. Respond `Y` for yes.
 
-image:./resources/images/mvn-training-create.png
+image::mvn-training-create.png[]
 
 This will create a new directory tree containing your new presentation,
 along with some sample content to get you started.
@@ -126,4 +126,3 @@ browser to start the presentation.
 
 * link:writing-slides.html[Writing Slides]
 * link:presentation-tips[Presentation Tips]
-


### PR DESCRIPTION
This fixes TRAINING-40.

The `new-presentation.adoc` guide already defines `:imagesdir: ../images/`, but the screenshot was referenced using a malformed path:

`image:./resources/images/mvn-training-create.png`

This change switches it to the standard AsciiDoc image macro so the existing `imagesdir` setting is used correctly:

`image::mvn-training-create.png[]`

I also verified that the referenced image exists under `site/src/site/resources/images/`.